### PR TITLE
Change listen requisite resolution from name to ID declaration

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2018,11 +2018,11 @@ class State(object):
             crefs[(chunk['state'], chunk['name'])] = chunk
             crefs[(chunk['state'], chunk['__id__'])] = chunk
             if 'listen' in chunk:
-                listeners.append({(chunk['state'], chunk['name']): chunk['listen']})
+                listeners.append({(chunk['state'], chunk['__id__']): chunk['listen']})
             if 'listen_in' in chunk:
                 for l_in in chunk['listen_in']:
                     for key, val in six.iteritems(l_in):
-                        listeners.append({(key, val): [{chunk['state']: chunk['name']}]})
+                        listeners.append({(key, val): [{chunk['state']: chunk['__id__']}]})
         mod_watchers = []
         errors = {}
         for l_dict in listeners:

--- a/tests/integration/files/file/base/requisites/listen_in_simple.sls
+++ b/tests/integration/files/file/base/requisites/listen_in_simple.sls
@@ -19,3 +19,21 @@ test_listening_change_state:
 test_listening_non_changing_state:
   cmd.run:
     - name: echo "Only run once"
+
+# test that requisite resolution for listen_in uses ID declaration.
+# test_listen_in_resolution should run.
+test_listen_in_resolution:
+  cmd.wait:
+    - name: echo "Successful listen_in resolution"
+
+successful_changing_state_name_foo:
+  test.succeed_with_changes:
+    - name: foo
+    - listen_in:
+      - cmd: test_listen_in_resolution
+
+successful_non_changing_state_name_foo:
+  test.succeed_without_changes:
+    - name: foo
+    - listen_in:
+      - cmd: test_listen_in_resolution

--- a/tests/integration/files/file/base/requisites/listen_simple.sls
+++ b/tests/integration/files/file/base/requisites/listen_simple.sls
@@ -19,3 +19,18 @@ test_listening_non_changing_state:
     - name: echo "Only run once"
     - listen:
       - pip: non_changing_state
+
+# test that requisite resolution for listen uses ID declaration.
+# test_listening_resolution_one and test_listening_resolution_two
+# should both run.
+test_listening_resolution_one:
+  cmd.run:
+    - name: echo "Successful listen resolution"
+    - listen:
+      - cmd: successful_changing_state
+
+test_listening_resolution_two:
+  cmd.run:
+    - name: echo "Successful listen resolution"
+    - listen:
+      - cmd: successful_changing_state

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -1041,6 +1041,32 @@ class StateModuleTest(integration.ModuleCase,
         absent_state = 'cmd_|-listener_test_listening_non_changing_state_|-echo "Only run once"_|-mod_watch'
         self.assertNotIn(absent_state, state_run)
 
+    def test_listen_in_requisite_resolution(self):
+        '''
+        Verify listen_in requisite lookups use ID declaration to check for changes
+        '''
+
+        # Only run the state once and keep the return data
+        state_run = self.run_function('state.sls', mods='requisites.listen_in_simple')
+
+        # Test the result of the state run when a listener is expected to trigger
+        listener_state = 'cmd_|-listener_test_listen_in_resolution_|-echo "Successful listen_in resolution"_|-mod_watch'
+        self.assertIn(listener_state, state_run)
+
+    def test_listen_requisite_resolution(self):
+        '''
+        Verify listen requisite lookups use ID declaration to check for changes
+        '''
+
+        # Only run the state once and keep the return data
+        state_run = self.run_function('state.sls', mods='requisites.listen_simple')
+
+        # Both listeners are expected to trigger
+        listener_state = 'cmd_|-listener_test_listening_resolution_one_|-echo "Successful listen resolution"_|-mod_watch'
+        self.assertIn(listener_state, state_run)
+
+        listener_state = 'cmd_|-listener_test_listening_resolution_two_|-echo "Successful listen resolution"_|-mod_watch'
+        self.assertIn(listener_state, state_run)
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
listen and listen_in resolution should use ID declaration instead of name to look up chunks for state changes. Without this change, triggers can be missed due to checking states of incorrect chunks, where those chunks have names in common but not ID declarations in common. The additional tests should make this issue obvious. At Lyft, we've been missing listen_in triggers due to states changing and then being cleared for the same name.
