### PR TITLE
Fix interaction of failhard and test=True mode.

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1662,6 +1662,8 @@ class State(object):
         Check if the low data chunk should send a failhard signal
         '''
         tag = _gen_tag(low)
+        if self.opts['test']:
+            return False
         if (low.get('failhard', False) or self.opts['failhard']
                 and tag in running):
             return not running[tag]['result']


### PR DESCRIPTION
In test mode many states will spuriously return False,
e.g. because a dependency created by an earlier state isn't present.
To avoid exiting a state run early on one of these spurious errors,
ignore failhard completely in test=True mode.

Backport of saltstack/salt#36199.