### PR TITLE
Teach highstate output to count pchanges as change during test

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -135,6 +135,8 @@ def _format_host(host, data):
 
             tcolor = colors['GREEN']
             schanged, ctext = _format_changes(ret['changes'])
+            if not ctext and 'pchanges' in ret:
+                schanged, ctext = _format_changes(ret['pchanges'])
             nchanges += 1 if schanged else 0
 
             # Skip this state if it was successful & diff output was requested


### PR DESCRIPTION
The blessed way of expressing "changes you want to make" is through the pchanges object in the return dict of state modules.

Lyft salt doesn't know about those, so teach it to output "what i want to change" in eg `state.highstate` test mode