### PR TITLE
Use the fast safe dumper when available

### DIFF
--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -10,6 +10,8 @@ from yaml.constructor import ConstructorError
 try:
     yaml.Loader = yaml.CLoader
     yaml.Dumper = yaml.CDumper
+    yaml.SafeLoader = yaml.CSafeLoader
+    yaml.SafeDumper = yaml.CSafeDumper
 except Exception:
     pass
 


### PR DESCRIPTION
this should result in a considerable load speed up (and significantly less cpu / memory) when rendering salt

backported from https://github.com/saltstack/salt/commit/cd051f0f4b9270d7fb1fa8631a0778445e4b0c0c